### PR TITLE
moved rdr.setSeries call up

### DIFF
--- a/bioformats/formatreader.py
+++ b/bioformats/formatreader.py
@@ -748,6 +748,10 @@ class ImageReader(object):
         :param channel_names: provide the channel names for the OME metadata
         :param XYWH: a (x, y, w, h) tuple
         '''
+        
+        if series is not None:
+            self.rdr.setSeries(series)
+        
         if XYWH is not None:
             assert isinstance(XYWH, tuple) and len(XYWH) == 4, "Invalid XYWH tuple"
             openBytes_func = lambda x: self.rdr.openBytesXYWH(x, XYWH[0], XYWH[1], XYWH[2], XYWH[3])
@@ -759,8 +763,7 @@ class ImageReader(object):
         ChannelSeparator = make_reader_wrapper_class(
             "loci/formats/ChannelSeparator")
         env = jutil.get_env()
-        if series is not None:
-            self.rdr.setSeries(series)
+        
 
         pixel_type = self.rdr.getPixelType()
         little_endian = self.rdr.isLittleEndian()


### PR DESCRIPTION
If the file contains series with different XY frame sizes, then one first has to set the series number, and then call the `rdr.getSizeX` and `rdr.getSizeY` functions
